### PR TITLE
Add Brier metrics to motion forecasting evaluation module

### DIFF
--- a/src/av2/datasets/motion_forecasting/eval/metrics.py
+++ b/src/av2/datasets/motion_forecasting/eval/metrics.py
@@ -16,7 +16,6 @@ def compute_ade(forecasted_trajectories: NDArrayNumber, gt_trajectory: NDArrayNu
     Returns:
         (K,) Average displacement error for each of the predicted trajectories.
     """
-    # (K,N)
     displacement_errors = np.linalg.norm(forecasted_trajectories - gt_trajectory, axis=2)  # type: ignore
     ade: NDArrayFloat = np.mean(displacement_errors, axis=1)
     return ade
@@ -56,3 +55,89 @@ def compute_is_missed_prediction(
     fde = compute_fde(forecasted_trajectories, gt_trajectory)
     is_missed_prediction = fde > miss_threshold_m  # type: ignore
     return is_missed_prediction
+
+
+def compute_brier_ade(
+    forecasted_trajectories: NDArrayNumber,
+    gt_trajectory: NDArrayNumber,
+    forecast_probabilities: NDArrayNumber,
+    normalize: bool = False,
+) -> NDArrayFloat:
+    """Compute a probability-weighted (using Brier score) ADE for K predicted trajectories (for the same actor).
+
+    Args:
+        forecasted_trajectories: (K, N, 2) predicted trajectories, each N timestamps in length.
+        gt_trajectory: (N, 2) ground truth trajectory.
+        forecast_probabilities: (K,) probabilities associated with each prediction.
+        normalize: Normalizes `forecast_probabilities` to sum to 1 when set to True.
+
+    Returns:
+        (K,) Probability-weighted average displacement error for each predicted trajectory.
+    """
+    # Compute ADE with Brier score component
+    brier_score = _compute_brier_score(forecasted_trajectories, forecast_probabilities, normalize)
+    ade_vector = compute_ade(forecasted_trajectories, gt_trajectory)
+    brier_ade: NDArrayFloat = ade_vector + brier_score
+    return brier_ade
+
+
+def compute_brier_fde(
+    forecasted_trajectories: NDArrayNumber,
+    gt_trajectory: NDArrayNumber,
+    forecast_probabilities: NDArrayNumber,
+    normalize: bool = False,
+) -> NDArrayFloat:
+    """Compute a probability-weighted (using Brier score) FDE for K predicted trajectories (for the same actor).
+
+    Args:
+        forecasted_trajectories: (K, N, 2) predicted trajectories, each N timestamps in length.
+        gt_trajectory: (N, 2) ground truth trajectory.
+        forecast_probabilities: (K,) probabilities associated with each prediction.
+        normalize: Normalizes `forecast_probabilities` to sum to 1 when set to True.
+
+    Returns:
+        (K,) Probability-weighted final displacement error for each predicted trajectory.
+    """
+    # Compute FDE with Brier score component
+    brier_score = _compute_brier_score(forecasted_trajectories, forecast_probabilities, normalize)
+    fde_vector = compute_fde(forecasted_trajectories, gt_trajectory)
+    brier_fde: NDArrayFloat = fde_vector + brier_score
+    return brier_fde
+
+
+def _compute_brier_score(
+    forecasted_trajectories: NDArrayNumber,
+    forecast_probabilities: NDArrayNumber,
+    normalize: bool = False,
+) -> NDArrayFloat:
+    """Compute Brier score for K predicted trajectories.
+
+    Note: This function computes Brier score under the assumption that each trajectory is the true "best" prediction
+    (i.e. each predicted trajectory has a ground truth probability of 1.0).
+
+    Args:
+        forecasted_trajectories: (K, N, 2) predicted trajectories, each N timestamps in length.
+        forecast_probabilities: (K,) probabilities associated with each prediction.
+        normalize: Normalizes `forecast_probabilities` to sum to 1 when set to True.
+
+    Raises:
+        ValueError: If the number of forecasted trajectories and probabilities don't match.
+        ValueError: If normalize=False and `forecast_probabilities` contains values outside of the range [0, 1].
+
+    Returns:
+        (K,) Brier score for each predicted trajectory.
+    """
+    # Validate that # of forecast probabilities matches forecasted trajectories
+    if len(forecasted_trajectories) != len(forecast_probabilities):
+        raise ValueError()
+
+    # Validate that all forecast probabilities are in the range [0, 1]
+    if np.logical_or(forecast_probabilities < 0.0, forecast_probabilities > 1.0).any():
+        raise ValueError("At least one forecast probability falls outside the range [0, 1].")
+
+    # If enabled, normalize forecast probabilities to sum to 1
+    if normalize:
+        forecast_probabilities = forecast_probabilities / np.sum(forecast_probabilities)
+
+    brier_score: NDArrayFloat = np.square((1 - forecast_probabilities))
+    return brier_score


### PR DESCRIPTION
## PR Summary
<!-- Authors: Add a description immediately below this line, explaining what was done and why it was done, and check the applicable boxes below. -->
This PR adds Brier score-based variants of ADE and FDE to the motion forecasting evaluation module.

These metrics are implemented in an identical way to their counterparts in the AV1 repo and will be used as scoring metrics in the AV2 MF challenge.

## Testing
<!-- Authors: Add testing details here, explaining your overall strategy, and check the applicable boxes below. -->
All functions added in this PR have been unit tested.

In order to ensure this PR works as intended, it is:

* [x] unit tested.
* [ ] other or not applicable (*additional detail/rationale required*)

## Compliance with Standards
<!-- Authors: Check each item below to certify that this PR is ready for review. -->

As the author, I certify that this PR conforms to the following standards:

* [x] Code changes conform to [PEP8](https://www.python.org/dev/peps/pep-0008) and docstrings conform to the Google Python [style guide](https://google.github.io/styleguide/pyguide.html?showone=Comments#38-comments-and-docstrings).
* [x] A well-written summary explains what was done and why it was done.
* [x] The PR is adequately tested and the testing details and links to external results are included.

<!-- Authors: If this PR is not ready for review, please create a "Draft Pull Request" using the dropdown below. -->