### PR TITLE
Add UNKNOWN lane mark type to map schema

### DIFF
--- a/src/av2/map/lane_segment.py
+++ b/src/av2/map/lane_segment.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from enum import Enum
+from enum import Enum, unique
 from typing import Any, Dict, Final, List, Optional
 
 import av2.geometry.infinity_norm_utils as infinity_norm_utils
@@ -20,6 +20,7 @@ WPT_INFINITY_NORM_INTERP_NUM: Final[int] = 50
 logger = logging.getLogger(__name__)
 
 
+@unique
 class LaneType(str, Enum):
     """Describes the sorts of objects that may use the lane for travel."""
 
@@ -28,6 +29,7 @@ class LaneType(str, Enum):
     BUS: str = "BUS"
 
 
+@unique
 class LaneMarkType(str, Enum):
     """Color and pattern of a painted lane marking, located on either the left or ride side of a lane segment.
 

--- a/src/av2/map/lane_segment.py
+++ b/src/av2/map/lane_segment.py
@@ -48,6 +48,7 @@ class LaneMarkType(str, Enum):
     SOLID_DASH_YELLOW: str = "SOLID_DASH_YELLOW"
     SOLID_BLUE: str = "SOLID_BLUE"
     NONE: str = "NONE"
+    UNKNOWN: str = "UNKNOWN"
 
 
 @dataclass


### PR DESCRIPTION
## PR Summary
<!-- Authors: Add a description immediately below this line, explaining what was done and why it was done, and check the applicable boxes below. -->
This PR adds an `UNKNOWN` lane mark type to the map schema.

This change resolves an issue where attempting to load a static map containing such a lane mark type would result in a failure and error being raised.

## Testing
<!-- Authors: Add testing details here, explaining your overall strategy, and check the applicable boxes below. -->
Tested by loading a scenario containing an `UNKNOWN` lane mark type.

In order to ensure this PR works as intended, it is:

* [ ] unit tested.
* [x] other or not applicable (*additional detail/rationale required*)

## Compliance with Standards
<!-- Authors: Check each item below to certify that this PR is ready for review. -->

As the author, I certify that this PR conforms to the following standards:

* [x] Code changes conform to [PEP8](https://www.python.org/dev/peps/pep-0008) and docstrings conform to the Google Python [style guide](https://google.github.io/styleguide/pyguide.html?showone=Comments#38-comments-and-docstrings).
* [x] A well-written summary explains what was done and why it was done.
* [x] The PR is adequately tested and the testing details and links to external results are included.

<!-- Authors: If this PR is not ready for review, please create a "Draft Pull Request" using the dropdown below. -->